### PR TITLE
feat: add change password modal to profile

### DIFF
--- a/src/components/views/ProfileView.jsx
+++ b/src/components/views/ProfileView.jsx
@@ -19,7 +19,16 @@ export default function ProfileView({
   loading,
   error,
   success,
+  passwordModalOpen,
+  passwordData,
+  setPasswordData,
+  passwordLoading,
+  passwordError,
+  passwordSuccess,
   handleSubmit,
+  handlePasswordSubmit,
+  openPasswordModal,
+  closePasswordModal,
   handleLogout,
   handlePhotoChange,
   ISRAELI_CITIES,
@@ -41,6 +50,103 @@ export default function ProfileView({
 
   return (
     <div className="profile-layout" style={styles.layout}>
+      {passwordModalOpen && (
+        <div style={styles.modalOverlay} onClick={closePasswordModal}>
+          <div style={styles.modal} onClick={(event) => event.stopPropagation()}>
+            <div style={styles.modalHeader}>
+              <div>
+                <h2 style={styles.modalTitle}>Change Password</h2>
+                <p style={styles.modalSubtitle}>
+                  Enter your current password before choosing a new one.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={closePasswordModal}
+                disabled={passwordLoading}
+                style={styles.closeButton}
+                aria-label="Close change password modal"
+              >
+                x
+              </button>
+            </div>
+
+            {passwordError && <div style={styles.errorBox}>{passwordError}</div>}
+            {passwordSuccess && <div style={styles.successBox}>{passwordSuccess}</div>}
+
+            <form onSubmit={handlePasswordSubmit}>
+              <div style={styles.field}>
+                <label>Current Password</label>
+                <input
+                  type="password"
+                  value={passwordData.currentPassword}
+                  onChange={(e) =>
+                    setPasswordData((prev) => ({
+                      ...prev,
+                      currentPassword: e.target.value,
+                    }))
+                  }
+                  required
+                  style={styles.input}
+                />
+              </div>
+
+              <div style={styles.field}>
+                <label>New Password</label>
+                <input
+                  type="password"
+                  value={passwordData.newPassword}
+                  onChange={(e) =>
+                    setPasswordData((prev) => ({
+                      ...prev,
+                      newPassword: e.target.value,
+                    }))
+                  }
+                  required
+                  style={styles.input}
+                />
+              </div>
+
+              <div style={styles.field}>
+                <label>Confirm New Password</label>
+                <input
+                  type="password"
+                  value={passwordData.confirmNewPassword}
+                  onChange={(e) =>
+                    setPasswordData((prev) => ({
+                      ...prev,
+                      confirmNewPassword: e.target.value,
+                    }))
+                  }
+                  required
+                  style={styles.input}
+                />
+              </div>
+
+              <div style={styles.modalActions}>
+                <button
+                  type="button"
+                  onClick={closePasswordModal}
+                  disabled={passwordLoading}
+                  style={styles.secondaryButton}
+                >
+                  Cancel
+                </button>
+
+                <button
+                  type="submit"
+                  disabled={passwordLoading}
+                  style={styles.button}
+                >
+                  {passwordLoading ? "Updating..." : "Update Password"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
       {menuOpen && (
         <div
           className="profile-overlay"
@@ -296,6 +402,14 @@ export default function ProfileView({
             </div>
 
             <div style={styles.actions}>
+              <button
+                type="button"
+                onClick={openPasswordModal}
+                style={styles.secondaryButton}
+              >
+                Change Password
+              </button>
+
               <button type="submit" disabled={loading} style={styles.button}>
                 {loading ? "Saving..." : "Save Changes"}
               </button>
@@ -626,6 +740,8 @@ const styles = {
   actions: {
     display: "flex",
     justifyContent: "flex-end",
+    gap: "12px",
+    flexWrap: "wrap",
     marginTop: "24px",
   },
 
@@ -635,6 +751,16 @@ const styles = {
     borderRadius: "14px",
     background: "#f97316",
     color: "white",
+    fontWeight: "800",
+    cursor: "pointer",
+  },
+
+  secondaryButton: {
+    border: "1px solid #f0c49d",
+    padding: "13px 24px",
+    borderRadius: "14px",
+    background: "#fff8ef",
+    color: "#e85d04",
     fontWeight: "800",
     cursor: "pointer",
   },
@@ -653,5 +779,68 @@ const styles = {
     padding: "12px",
     borderRadius: "12px",
     marginBottom: "16px",
+  },
+
+  modalOverlay: {
+    position: "fixed",
+    inset: 0,
+    background: "rgba(43, 22, 12, 0.35)",
+    display: "grid",
+    placeItems: "center",
+    padding: "18px",
+    zIndex: 100,
+  },
+
+  modal: {
+    width: "100%",
+    maxWidth: "460px",
+    background: "white",
+    borderRadius: "24px",
+    padding: "26px",
+    boxShadow: "0 24px 80px rgba(43, 22, 12, 0.18)",
+    border: "1px solid #f2e7dc",
+    boxSizing: "border-box",
+  },
+
+  modalHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: "16px",
+    marginBottom: "20px",
+  },
+
+  modalTitle: {
+    margin: 0,
+    color: "#173b2f",
+    fontSize: "24px",
+    fontWeight: "900",
+  },
+
+  modalSubtitle: {
+    margin: "8px 0 0",
+    color: "#6b625c",
+    fontSize: "13px",
+    fontWeight: "400",
+  },
+
+  closeButton: {
+    width: "34px",
+    height: "34px",
+    border: "none",
+    borderRadius: "12px",
+    background: "#fff1df",
+    color: "#e85d04",
+    fontSize: "18px",
+    fontWeight: "900",
+    cursor: "pointer",
+  },
+
+  modalActions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    gap: "12px",
+    flexWrap: "wrap",
+    marginTop: "8px",
   },
 };

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import ProfileView from "../components/views/ProfileView";
 import { updateUserProfile } from "../services/userService";
-import { logoutUser } from "../services/authService";
+import { changeUserPassword, logoutUser } from "../services/authService";
 
 const ISRAELI_CITIES = [
   "Jerusalem",
@@ -28,6 +28,10 @@ function Profile() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
+  const [passwordSuccess, setPasswordSuccess] = useState("");
+  const [passwordModalOpen, setPasswordModalOpen] = useState(false);
 
   const [citySearch, setCitySearch] = useState("");
   const [showCityDropdown, setShowCityDropdown] = useState(false);
@@ -38,6 +42,12 @@ function Profile() {
     city: "",
     is_available: true,
     photo_url: "",
+  });
+
+  const [passwordData, setPasswordData] = useState({
+    currentPassword: "",
+    newPassword: "",
+    confirmNewPassword: "",
   });
 
   useEffect(() => {
@@ -77,6 +87,61 @@ function Profile() {
       photo_url: previewUrl,
       photo_file: file,
     }));
+  };
+
+  const openPasswordModal = () => {
+    setPasswordData({
+      currentPassword: "",
+      newPassword: "",
+      confirmNewPassword: "",
+    });
+    setPasswordError("");
+    setPasswordSuccess("");
+    setPasswordModalOpen(true);
+  };
+
+  const closePasswordModal = () => {
+    if (passwordLoading) return;
+
+    setPasswordModalOpen(false);
+    setPasswordError("");
+    setPasswordSuccess("");
+    setPasswordData({
+      currentPassword: "",
+      newPassword: "",
+      confirmNewPassword: "",
+    });
+  };
+
+  const handlePasswordSubmit = async (event) => {
+    event.preventDefault();
+
+    setPasswordLoading(true);
+    setPasswordError("");
+    setPasswordSuccess("");
+
+    try {
+      if (passwordData.newPassword !== passwordData.confirmNewPassword) {
+        throw new Error("New passwords do not match.");
+      }
+
+      await changeUserPassword(
+        passwordData.currentPassword,
+        passwordData.newPassword
+      );
+
+      setPasswordSuccess("Password changed successfully!");
+      setPasswordData({
+        currentPassword: "",
+        newPassword: "",
+        confirmNewPassword: "",
+      });
+    } catch (err) {
+      console.error(err);
+      setPasswordError(err.message || "Failed to change password");
+    } finally {
+      setPasswordLoading(false);
+    }
   };
 
   const handleSubmit = async (event) => {
@@ -125,7 +190,16 @@ function Profile() {
       loading={loading}
       error={error}
       success={success}
+      passwordModalOpen={passwordModalOpen}
+      passwordData={passwordData}
+      setPasswordData={setPasswordData}
+      passwordLoading={passwordLoading}
+      passwordError={passwordError}
+      passwordSuccess={passwordSuccess}
       handleSubmit={handleSubmit}
+      handlePasswordSubmit={handlePasswordSubmit}
+      openPasswordModal={openPasswordModal}
+      closePasswordModal={closePasswordModal}
       handleLogout={handleLogout}
       handlePhotoChange={handlePhotoChange}
       ISRAELI_CITIES={ISRAELI_CITIES}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,9 +1,12 @@
 import {
   createUserWithEmailAndPassword,
+  EmailAuthProvider,
   signInWithEmailAndPassword,
   signOut,
   onAuthStateChanged,
    getAuth ,
+  reauthenticateWithCredential,
+  updatePassword,
 } from "firebase/auth";
 
 import { auth, firebaseConfig, } from "../firebase";
@@ -150,6 +153,37 @@ export async function logoutUser() {
     console.error("Logout user failed:", error);
 
     throw new Error("Logout failed. Please try again.");
+  }
+}
+
+// Change the current user's password after confirming their current password
+export async function changeUserPassword(currentPassword, newPassword) {
+  try {
+    const currentUser = auth.currentUser;
+
+    if (!currentUser?.email) {
+      throw new Error("No authenticated user found.");
+    }
+
+    validateEmailAndPassword(currentUser.email, currentPassword);
+
+    if (!newPassword) {
+      throw new Error("New password is required.");
+    }
+
+    const credential = EmailAuthProvider.credential(
+      currentUser.email,
+      currentPassword
+    );
+
+    await reauthenticateWithCredential(currentUser, credential);
+    await updatePassword(currentUser, newPassword);
+
+    return true;
+  } catch (error) {
+    console.error("Change password failed:", error);
+
+    throw new Error(getAuthErrorMessage(error), { cause: error });
   }
 }
 


### PR DESCRIPTION
This PR introduces the Change Password feature on the Profile page, allowing users to securely update their account passwords through a dedicated modal. A new "Change Password" button was added to the Profile view, which opens a modal containing fields for the current password, new password, and password confirmation. The implementation includes password validation logic and user feedback to ensure a secure and smooth experience. Testing was performed to verify that the modal opens correctly from the profile page and that the password update flow functions as expected while enforcing the defined validation rules.
